### PR TITLE
Suggested solution for lazy loading of growly Issue #2

### DIFF
--- a/lib/growly.js
+++ b/lib/growly.js
@@ -202,7 +202,7 @@ function Growly() {
     this.notifications = undefined;
     this.labels = undefined;
     this.count = 0;
-    this.register(this.appname);
+    this.initialized = false;
 }
 
 /**
@@ -242,10 +242,11 @@ Growly.prototype.getLabels = function() {
  * @param {String} appname
  * @param {String|Buffer} appicon
  * @param {Array} notifications
+ * @param {Function} callback
  * @api public
  */
 
-Growly.prototype.register = function(appname, appicon, notifications) {
+Growly.prototype.register = function(appname, appicon, notifications, callback) {
     var req;
 
     if (typeof appicon === 'object') {
@@ -260,6 +261,7 @@ Growly.prototype.register = function(appname, appicon, notifications) {
     this.appname = appname;
     this.notifications = notifications;
     this.labels = this.getLabels();
+    this.initialized = true;
 
     req = new GNTP('REGISTER');
     req.add('Application-Name', appname);
@@ -278,6 +280,7 @@ Growly.prototype.register = function(appname, appicon, notifications) {
 
     req.send(function(err, resp) {
         if (err) console.log(err);
+        if (callback) callback();
     });
 };
 
@@ -307,8 +310,28 @@ Growly.prototype.register = function(appname, appicon, notifications) {
  * @param {Function} callback
  * @api public
  */
-
 Growly.prototype.notify = function(text, opts, callback) {
+    var that = this;
+
+    var execution = function(){
+        that._notify(text, opts, callback);
+    }
+    //Lazy construction;
+    if (this.initialized === false){
+            this.register(this.appname, undefined, undefined, execution);
+            this.initialized = true;
+    } else {
+            execution();
+    }
+}
+
+/**
+ * Private notify invocation to wrap as a callback, and support callback.
+ *
+ */
+Growly.prototype._notify = function(text, opts, callback) {
+
+
     var req, id = ++this.count;
     opts = opts || {};
 
@@ -333,8 +356,10 @@ Growly.prototype.notify = function(text, opts, callback) {
     req.newline();
 
     req.send(function(err, resp) {
-        if (err && callback)
-            callback(err);
+        if (err){
+            if (callback) callback(err);
+            return;
+        }
         if (resp.state === 'CALLBACK' && callback)
             callback(undefined, resp['Notification-Callback-Result'].toLowerCase());
     });


### PR DESCRIPTION
So, here is suggested fix for this issue.

In short, we have  a scenario where we want to have a growly available:

``` js
var growly = require ('growly');
```

However, we do not expect this to already connect to the server at that point.

I've added a suggested fix in which the initial connection done in the Growly() constructor is delayed to the point where notify() is invoked.
