### PR TITLE
Fix a crash when Growly.notify is called without callback.

### DIFF
--- a/lib/growly.js
+++ b/lib/growly.js
@@ -162,9 +162,9 @@ Growly.prototype.notify = function(text, opts, callback) {
     gntp.newline();
 
     gntp.send(function(err, resp) {
-        if (err && callback) {
+        if (callback && err) {
             callback(err);
-        } else if (resp.state === 'CALLBACK' && callback) {
+        } else if (callback && resp.state === 'CALLBACK') {
             callback(undefined, resp['Notification-Callback-Result'].toLowerCase());
         }
     });


### PR DESCRIPTION
When Growly.notify is called without callback and an error happens
(err is an Error instance and resp is undefined), then an exception 
is thrown because 'resp.state' is checked before 'callback':

TypeError: Cannot read property 'state' of undefined
    at Growly.notify (/usr/lib/node_modules/testacular/node_modules/growly/lib/growly.js:167:24)
    at Socket.GNTP.send (/usr/lib/node_modules/testacular/node_modules/growly/lib/gntp.js:194:9)
    at Socket.EventEmitter.emit (events.js:96:17)
    at Socket._destroy.self.errorEmitted (net.js:329:14)
    at process.startup.processNextTick.process._tickCallback (node.js:244:9)
