### PR TITLE
update gntp.js

### DIFF
--- a/lib/gntp.js
+++ b/lib/gntp.js
@@ -83,7 +83,7 @@ GNTP.prototype.retry = function() {
  */
 
 GNTP.prototype.addResource = function(file) {
-    var id = crypto.createHash('md5').update(file).digest('hex'),
+    var id = crypto.createHash('sha256').update(file).digest('base64');
         header = 'Identifier: ' + id + nl + 'Length: ' + file.length + nl + nl;
     this.resources.push({ header: header, file: file });
     return 'x-growl-resource://' + id;


### PR DESCRIPTION
md5 is a weak tech. please use sha instead of md5. If you r using md5 for any reason, its still a security issue.